### PR TITLE
docs : Updated code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ function* integers() {
 
 ```javascript
 const { map, filter, reduce, take, skip } = require('rxjs/operators');
-const transducer = require('rxjs-transducer');
+const { transducer } = require('rxjs-transducer');
 const source = ['a', 'ab', 'abc', 'abcd', 'abcde'];
 
 const result = transducer(source)(


### PR DESCRIPTION
- Importing a CommonJS module directly results in returning a type error, so instead of pointing it a variable retrieve the function from it.